### PR TITLE
Remove removed package Issues

### DIFF
--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -17,7 +17,6 @@
 		"Grunt",
 		"Increment Selection",
 		"INI",
-		"Issues",
 		"LESS",
 		"Markdown Extended",
 		"Markdown Preview",


### PR DESCRIPTION
The `Issues` package is no longer available through Package Control and is emitting errors during installation.
